### PR TITLE
add DefaultNbFramesPerSecond for 30

### DIFF
--- a/ASBPlayerSubtitling/ASBPlayerSubtitling.m
+++ b/ASBPlayerSubtitling/ASBPlayerSubtitling.m
@@ -9,6 +9,8 @@
 #import "ASBPlayerSubtitling.h"
 #import <UIKit/UIKit.h>
 
+static CGFloat *const DefaultNbFramesPerSecond = 30;
+
 @implementation ASBSubtitle
 @end
 
@@ -53,6 +55,9 @@
     _player = player;
     
     self.nbFramesPerSecond = [ASBPlayerSubtitling nominalFrameRateForPlayer:self.player];
+    if (self.nbFramesPerSecond == 0) {
+        self.nbFramesPerSecond = DefaultNbFramesPerSecond;
+    }
     self.frameDuration = 1/self.nbFramesPerSecond;
     self.label.text = @"";
     self.containerView.hidden = YES;


### PR DESCRIPTION
For some urls that AVPlayer could not extract `AVAssetTrack`, I add default nbFramesPerSecond by 30.